### PR TITLE
Sorting List by Purchase Estimate US 12

### DIFF
--- a/src/components/AddItem.jsx
+++ b/src/components/AddItem.jsx
@@ -85,13 +85,14 @@ function AddItem() {
       return;
     }
     try {
-      // Add a new document/item in collection/localToken under normilized item name  (use it as unique id)
+      // Add a new document/item in collection/localToken under normalized item name  (use it as unique id)
       await setDoc(doc(db, localToken, itemNameNormalized), {
         createdAt: Date.now(),
         itemName,
         previousEstimate: Number(frequency),
         purchasedDate: null,
         totalPurchases: 0,
+        isActive: false,
       });
       toast.success(`Successfully added ${itemName}`);
 

--- a/src/components/ListLayout.jsx
+++ b/src/components/ListLayout.jsx
@@ -62,9 +62,6 @@ const ListLayout = ({ items, localToken }) => {
     return timeCheck;
   }
 
-  //this sorts by previousEstimate (calculation of when user will buy the item again) Note: items is already sorted alphabetically by item Id which is the normalized item name
-  items.sort((itemA, itemB) => itemA.previousEstimate - itemB.previousEstimate);
-
   // updates isActive property of item to true if item has 2+ purchases and has been purchased within calculated estimate
   // isActive is defaulted to false when item is added
   items.forEach((item) => {
@@ -83,6 +80,35 @@ const ListLayout = ({ items, localToken }) => {
       setUpdateToDb(localToken, item.id, itemToUpdate);
     }
   });
+
+  //this sorts by previousEstimate (calculation of when user will buy the item again) Note: items is already sorted alphabetically by item Id which is the normalized item name
+  items
+    .sort((itemA, itemB) => itemA.previousEstimate - itemB.previousEstimate)
+    .sort((itemA, itemB) => Number(itemB.isActive) - Number(itemA.isActive));
+  let frequencyGroup;
+  function colorClass(item) {
+    //inactive = gray
+    if (!item.isActive) {
+      frequencyGroup = 'inactive';
+      return 'bg-gray-300';
+    }
+
+    //buy soon
+    else if (item.previousEstimate < 7) {
+      frequencyGroup = 'buy soon';
+      return 'bg-green-500';
+    }
+    //kind of soon
+    else if (item.previousEstimate < 30) {
+      frequencyGroup = 'kind of soon';
+      return 'bg-yellow-400';
+    }
+    //not so soon
+    else {
+      frequencyGroup = 'not so soon';
+      return 'bg-rose-300';
+    }
+  }
 
   return (
     <>
@@ -121,13 +147,13 @@ const ListLayout = ({ items, localToken }) => {
           <ImCross />
         </button>
       </div>
-      <ul className="grid grid-cols-2 justify-around">
+      <ul className="grid grid-cols-3 justify-around">
         {items
           .filter((item) => item.id.includes(filter.toLowerCase()))
           .map((item, idx) => (
-            <li className="flex flex-col my-4" key={idx}>
+            <li className={`flex flex-col my-4 ${colorClass(item)}`} key={idx}>
               <div>
-                {` Item Name: ${item.itemName}`}{' '}
+                {`Item Name: ${item.itemName}`}{' '}
                 <input
                   type="checkbox"
                   checked={within24hours(item.purchasedDate)}
@@ -137,6 +163,7 @@ const ListLayout = ({ items, localToken }) => {
                 />
               </div>
               <div>{` Frequency: ${item.previousEstimate}`}</div>
+              <div>{`Need to buy? ${frequencyGroup}`}</div>
             </li>
           ))}
       </ul>

--- a/src/components/ListLayout.jsx
+++ b/src/components/ListLayout.jsx
@@ -9,7 +9,6 @@ import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
 const setUpdateToDb = async (collection, itemId, dataToUpdate) => {
   const itemRef = doc(db, collection, itemId);
   await updateDoc(itemRef, dataToUpdate);
-  console.log('await finished');
 };
 
 const ListLayout = ({ items, localToken }) => {
@@ -162,7 +161,7 @@ const ListLayout = ({ items, localToken }) => {
                   aria-label={item.itemName} //what do we want to call this ('item', 'item.itemName', 'purchased item' .....)
                 />
               </div>
-              <div>{` Frequency: ${item.previousEstimate}`}</div>
+              <div>{` Estimated time til purchase: ${item.previousEstimate}`}</div>
               <div>{`Need to buy? ${frequencyGroup}`}</div>
             </li>
           ))}

--- a/src/components/ListLayout.jsx
+++ b/src/components/ListLayout.jsx
@@ -100,7 +100,7 @@ const ListLayout = ({ items, localToken }) => {
     //kind of soon
     else if (item.previousEstimate < 30) {
       frequencyGroup = 'kind of soon';
-      return 'bg-yellow-400';
+      return '';
     }
     //not so soon
     else {
@@ -108,6 +108,46 @@ const ListLayout = ({ items, localToken }) => {
       return 'bg-rose-300';
     }
   }
+
+  const filteredItems = items.filter((item) =>
+    item.id.includes(filter.toLowerCase()),
+  );
+
+  const groups = [
+    {
+      label: 'Soon',
+      sublabel: "We think you'll need this in less than 7 days",
+      groupFilter: (item) => {
+        return item.previousEstimate < 7 && item.isActive === true;
+      },
+      // classStyle: 'bg-yellow-400'
+    },
+    {
+      label: 'Kind of soon',
+      sublabel: "We think you'll need this in less than 7 days",
+      groupFilter: (item) => {
+        return (
+          item.previousEstimate >= 7 &&
+          item.previousEstimate < 30 &&
+          item.isActive === true
+        );
+      },
+    },
+    {
+      label: 'Not soon',
+      sublabel: "We think you'll need this in less than 7 days",
+      groupFilter: (item) => {
+        return item.previousEstimate >= 30 && item.isActive === true;
+      },
+    },
+    {
+      label: 'Inactive',
+      sublabel: "We think you'll need this in less than 7 days",
+      groupFilter: (item) => {
+        return item.isActive === false;
+      },
+    },
+  ];
 
   return (
     <>
@@ -146,26 +186,40 @@ const ListLayout = ({ items, localToken }) => {
           <ImCross />
         </button>
       </div>
-      <ul className="grid grid-cols-3 justify-around">
-        {items
-          .filter((item) => item.id.includes(filter.toLowerCase()))
-          .map((item, idx) => (
-            <li className={`flex flex-col my-4 ${colorClass(item)}`} key={idx}>
-              <div>
-                {`Item Name: ${item.itemName}`}{' '}
-                <input
-                  type="checkbox"
-                  checked={within24hours(item.purchasedDate)}
-                  onChange={(e) => handleCheckboxChange(e)}
-                  name={item.id}
-                  aria-label={item.itemName} //what do we want to call this ('item', 'item.itemName', 'purchased item' .....)
-                />
-              </div>
-              <div>{` Estimated time til purchase: ${item.previousEstimate}`}</div>
-              <div>{`Need to buy? ${frequencyGroup}`}</div>
-            </li>
-          ))}
-      </ul>
+
+      {groups.map((group, idx) => (
+        <section key={idx} className="mt-6">
+          <div className="flex justify-between border-b-2">
+            <h1 className="text-xl font-semibold text-blue-700">
+              {group.label}
+            </h1>
+            <p className="text-gray-500">{group.sublabel}</p>
+          </div>
+          <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 justify-around">
+            {filteredItems
+              .filter((item) => group.groupFilter(item))
+              .map((item, idx) => (
+                <li
+                  className={`flex flex-col my-4 ${colorClass(item)}`}
+                  key={idx}
+                >
+                  <div>
+                    {`Item Name: ${item.itemName}`}{' '}
+                    <input
+                      type="checkbox"
+                      checked={within24hours(item.purchasedDate)}
+                      onChange={(e) => handleCheckboxChange(e)}
+                      name={item.id}
+                      aria-label={item.itemName} //what do we want to call this ('item', 'item.itemName', 'purchased item' .....)
+                    />
+                  </div>
+                  <div>{` Estimated time til purchase: ${item.previousEstimate}`}</div>
+                  <div>{`Need to buy? ${frequencyGroup}`}</div>
+                </li>
+              ))}
+          </ul>
+        </section>
+      ))}
     </>
   );
 };

--- a/src/components/ListLayout.jsx
+++ b/src/components/ListLayout.jsx
@@ -112,7 +112,7 @@ const ListLayout = ({ items, localToken }) => {
       label: 'Not soon',
       sublabel: "We think you'll need this in more than 30 days",
       groupFilter: (item) => {
-        return item.previousEstimate >= 30 && item.isActive;
+        return item.previousEstimate >= 30 && item.isActive === true;
       },
       colorClass: 'bg-green-100',
     },


### PR DESCRIPTION
## Description

We added an isActive data point to each item on /AddItem and we are setting the isActive data point to true in /listItem if there are more than 2 purchases and the days since last transaction is not greater than 2 * the previous estimate. 

We added sorting algorithms to the list sorting by previous estimate then sorting by inActive property, this sorts by dates and then places any inactive items at the bottom of the list. 
Note: Firebase sorts alphabetically by item Id so 2 items with the same previous estimate will be sorted alphabetically.

We set a "Need to buy" temporary text for each item to convey the estimate in a written rather than visual way, would love ideas on restructuring this! Shelley had a great idea to group the items together based on frequency and isActive but we weren't sure on how to do that without breaking up the list and doing separate renders.

We made a function to return tailwind classes based on how soon a user is expected to purchase an item and set temporary colors for each item:

- if an item's estimated purchase days are < 7 the background color is set to green for that item

- if an item's estimated purchase days are < 30 the background color is set to yellow for that item

- if an item's estimated purchase days are >=30 the background color is set to rose for that item

- if an item's isActive property is false the background color is set to gray.

## Related Issue

closes #12 

## Acceptance Criteria

* Need to buy soon (fewer than 7 days)
* Need to buy kind of soon (between 7 & 30 days)
* Need to buy not soon (more than 30 days)
* Inactive (when there’s only 1 purchase in the database or the purchase is really out of date [the time that has elapsed since the last purchase is 2x what was estimated])
AC:
* Items in the list are shown as visually distinct (e.g., with a different background color on the list item) according to how soon the item is expected to be bought again: Soon, Kind of soon, Not soon, Inactive
* Items should be sorted by the estimated number of days until the next purchase
* Items with the same number of estimated days until next purchase should be sorted alphabetically
* Items in the different states should be described distinctly when read by a screen reader


## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before
![screencapture-tcl-36-smart-shopping-list-web-app-listView-2022-02-16-10_42_23](https://user-images.githubusercontent.com/89806097/154333967-33e101c4-50da-4b63-acb0-83c94a703fd8.png)

### After

![screencapture-localhost-3000-listView-2022-02-16-10_39_44](https://user-images.githubusercontent.com/89806097/154333603-0090cac7-5870-4b2d-bf4b-4402c654c7ee.png)



## Testing Steps / QA Criteria

1. After pulling down this branch to your local environment, run npm start
2. You can join the list we have been working on by running this in your browser console: localStorage.setItem('list-token', 'trust eclat shot'), and then navigating to /listView. You can also try creating a new list with your own items but to see active items you would need to change multiple data points in firebase so that the isActive property can evaluate to true.

