### PR TITLE
Refactoring render for empty groups

### DIFF
--- a/src/components/ListLayout.jsx
+++ b/src/components/ListLayout.jsx
@@ -133,33 +133,33 @@ const ListLayout = ({ items, localToken }) => {
                 //the matching group items are then mapped together in the section they belong
                 filteredItems
                   .filter((item) => group.groupFilter(item))
-             .map((item, idx) => {
-                  return (
-                    <li className={`flex flex-col py-4`} key={idx}>
-                      <div className="flex">
-                        <h4 className="px-4">{`Item Name: ${item.itemName}`}</h4>
-                        <input
-                          type="checkbox"
-                          checked={isWithin24hours(item.purchasedDate)}
-                          onChange={(e) => handleCheckboxChange(e)}
-                          name={item.id}
-                          aria-label={item.itemName}
-                        />
-                        <button
-                          aria-label={`delete ${item.id} button`}
-                          className="bg-blue-500 hover:bg-blue-700 text-white ml-4 font-bold py-1 px-1 rounded"
-                          onClick={() =>
-                            deleteButtonPressed(item.id, item.itemName)
-                          }
-                        >
-                          <RiDeleteBin6Fill />
-                        </button>
-                      </div>
-                      <div className="px-4">{` Time until next purchase: ${item.previousEstimate}`}</div>
-                      <div className="px-4">{` Total purchases: ${item.totalPurchases}`}</div>
-                    </li>
-                  );
-                })}
+                  .map((item, idx) => {
+                    return (
+                      <li className={`flex flex-col py-4`} key={idx}>
+                        <div className="flex">
+                          <h4 className="px-4">{`Item Name: ${item.itemName}`}</h4>
+                          <input
+                            type="checkbox"
+                            checked={isWithin24hours(item.purchasedDate)}
+                            onChange={(e) => handleCheckboxChange(e)}
+                            name={item.id}
+                            aria-label={item.itemName}
+                          />
+                          <button
+                            aria-label={`delete ${item.id} button`}
+                            className="bg-blue-500 hover:bg-blue-700 text-white ml-4 font-bold py-1 px-1 rounded"
+                            onClick={() =>
+                              deleteButtonPressed(item.id, item.itemName)
+                            }
+                          >
+                            <RiDeleteBin6Fill />
+                          </button>
+                        </div>
+                        <div className="px-4">{` Time until next purchase: ${item.previousEstimate}`}</div>
+                        <div className="px-4">{` Total purchases: ${item.totalPurchases}`}</div>
+                      </li>
+                    );
+                  })
               ) : (
                 <p className="col-span-3">
                   There are no items needed in this time frame

--- a/src/components/ListLayout.jsx
+++ b/src/components/ListLayout.jsx
@@ -180,26 +180,29 @@ const ListLayout = ({ items, localToken }) => {
             <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 justify-around">
               {filteredItems
                 //groupFilter is a callback that returns true if an item matches the criteria for group category
-                .filter((item) => group.groupFilter(item))
-                //the matching group items are then mapped together in the section they belong
-                .map((item, idx) => {
-                  return (
-                    <li className={`flex flex-col py-4`} key={idx}>
-                      <div className="flex">
-                        <h4 className="px-4">{`Item Name: ${item.itemName}`}</h4>
-                        <input
-                          type="checkbox"
-                          checked={within24hours(item.purchasedDate)}
-                          onChange={(e) => handleCheckboxChange(e)}
-                          name={item.id}
-                          aria-label={item.itemName}
-                        />
-                      </div>
-                      <div className="px-4">{` Time until next purchase: ${item.previousEstimate}`}</div>
-                      <div className="px-4">{` Total purchases: ${item.totalPurchases}`}</div>
-                    </li>
-                  );
-                })}
+                .filter((item) => group.groupFilter(item)).length > 0
+                ? //the matching group items are then mapped together in the section they belong
+                  filteredItems
+                    .filter((item) => group.groupFilter(item))
+                    .map((item, idx) => {
+                      return (
+                        <li className={`flex flex-col py-4`} key={idx}>
+                          <div className="flex">
+                            <h4 className="px-4">{`Item Name: ${item.itemName}`}</h4>
+                            <input
+                              type="checkbox"
+                              checked={within24hours(item.purchasedDate)}
+                              onChange={(e) => handleCheckboxChange(e)}
+                              name={item.id}
+                              aria-label={item.itemName}
+                            />
+                          </div>
+                          <div className="px-4">{` Time until next purchase: ${item.previousEstimate}`}</div>
+                          <div className="px-4">{` Total purchases: ${item.totalPurchases}`}</div>
+                        </li>
+                      );
+                    })
+                : 'There are no items needed in this time frame'}
             </ul>
           </section>
         ))

--- a/src/components/ListLayout.jsx
+++ b/src/components/ListLayout.jsx
@@ -180,29 +180,33 @@ const ListLayout = ({ items, localToken }) => {
             <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 justify-around">
               {filteredItems
                 //groupFilter is a callback that returns true if an item matches the criteria for group category
-                .filter((item) => group.groupFilter(item)).length > 0
-                ? //the matching group items are then mapped together in the section they belong
-                  filteredItems
-                    .filter((item) => group.groupFilter(item))
-                    .map((item, idx) => {
-                      return (
-                        <li className={`flex flex-col py-4`} key={idx}>
-                          <div className="flex">
-                            <h4 className="px-4">{`Item Name: ${item.itemName}`}</h4>
-                            <input
-                              type="checkbox"
-                              checked={within24hours(item.purchasedDate)}
-                              onChange={(e) => handleCheckboxChange(e)}
-                              name={item.id}
-                              aria-label={item.itemName}
-                            />
-                          </div>
-                          <div className="px-4">{` Time until next purchase: ${item.previousEstimate}`}</div>
-                          <div className="px-4">{` Total purchases: ${item.totalPurchases}`}</div>
-                        </li>
-                      );
-                    })
-                : 'There are no items needed in this time frame'}
+                .filter((item) => group.groupFilter(item)).length > 0 ? (
+                //the matching group items are then mapped together in the section they belong
+                filteredItems
+                  .filter((item) => group.groupFilter(item))
+                  .map((item, idx) => {
+                    return (
+                      <li className={`flex flex-col py-4`} key={idx}>
+                        <div className="flex">
+                          <h4 className="px-4">{`Item Name: ${item.itemName}`}</h4>
+                          <input
+                            type="checkbox"
+                            checked={within24hours(item.purchasedDate)}
+                            onChange={(e) => handleCheckboxChange(e)}
+                            name={item.id}
+                            aria-label={item.itemName}
+                          />
+                        </div>
+                        <div className="px-4">{` Time until next purchase: ${item.previousEstimate}`}</div>
+                        <div className="px-4">{` Total purchases: ${item.totalPurchases}`}</div>
+                      </li>
+                    );
+                  })
+              ) : (
+                <p className="col-span-3">
+                  There are no items needed in this time frame
+                </p>
+              )}
             </ul>
           </section>
         ))


### PR DESCRIPTION
## Description

We added conditional logic in the render so that if a group has no items filtered to it, that group will display a message indicating no items match so that the user understands why that group is empty. We decided to still display the group section so that the user can get an idea of the sorting functionality and predictive capabilities of the list even if they have no items to match that list.

Additional refactoring including accordion style containers was discussed but to prevent feature creep we decided to implement conditional rendering first with the option for UI and structural refactoring asynchronously.

## Related Issue

closes #32 

## Acceptance Criteria

- [ ] Displays a message for empty groups indicating no items are in the group

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  | :sparkles: New feature     |
|   ✓  | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before

![empty group with no items](https://user-images.githubusercontent.com/89806097/155609103-b9688dae-a2ce-4006-b72e-badbc517a2f2.png)



### After


![with no items text added](https://user-images.githubusercontent.com/89806097/155609147-c2d31987-e8ba-4323-931e-28136fd45553.png)



