### PR TITLE
Gradient frame added, warnings fixed

### DIFF
--- a/src/components/AddItem.jsx
+++ b/src/components/AddItem.jsx
@@ -81,7 +81,7 @@ function AddItem() {
   return (
     <>
       <Toaster />
-      <div className="container flex w-1/2 mx-auto p-8 rounded-3xl border-8 border-teal-500 bg-white">
+      <div className="container flex w-3/4 md:w-1/2 mx-auto p-8 rounded-3xl border-8 border-teal-500 bg-white">
         <form method="post">
           <label htmlFor="itemName">Item Name:</label>
           <input
@@ -90,7 +90,7 @@ function AddItem() {
             name="itemName"
             ref={inputRef}
             value={itemName}
-            className="ml-2 mb-4 border rounded"
+            className="md:ml-2 mb-4 border rounded"
             onChange={(e) => setItemName(e.target.value)}
           ></input>
 

--- a/src/components/GradientFrame.jsx
+++ b/src/components/GradientFrame.jsx
@@ -2,15 +2,13 @@ import React from 'react';
 
 function GradientFrame({ children, colorClass }) {
   return (
-    <>
-      <section
-        className={`rounded-3xl  mx-auto  mt-6 p-2 bg-gradient-to-b ${colorClass}`}
-      >
-        <div className="flex flex-col justify-between  py-10 bg-white rounded-3xl p-4">
-          {children}
-        </div>
-      </section>
-    </>
+    <section
+      className={`rounded-3xl  mx-auto  mt-6 p-2 bg-gradient-to-b ${colorClass}`}
+    >
+      <div className="flex flex-col justify-between  py-10 bg-white rounded-3xl p-4">
+        {children}
+      </div>
+    </section>
   );
 }
 

--- a/src/components/GradientFrame.jsx
+++ b/src/components/GradientFrame.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+function GradientFrame({ children, colorClass }) {
+  return (
+    <>
+      <section
+        className={`rounded-3xl  mx-auto  mt-6 p-2 bg-gradient-to-b ${colorClass}`}
+      >
+        <div className="flex flex-col justify-between  py-10 bg-white rounded-3xl p-4">
+          {children}
+        </div>
+      </section>
+    </>
+  );
+}
+
+export default GradientFrame;

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -50,7 +50,7 @@ function Home() {
   };
 
   return (
-    <div className="text-center w-1/2 mx-auto">
+    <div className="text-center w-3/4 md:w-1/2 mx-auto">
       <main className="flex flex-col flex-justify items-center text-white p-6 rounded-3xl border-8 border-teal-500">
         <Toaster />
         <p className="text-2xl mb-4">Welcome to Smart Shopper.</p>

--- a/src/components/ListLayout.jsx
+++ b/src/components/ListLayout.jsx
@@ -250,7 +250,11 @@ const ListLayout = ({ items, localToken }) => {
                             itemsGrouped.map((item, idx) => {
                               return (
                                 <tr key={item.id} className="h-8">
-                                  <td>{`${item.itemName}`}</td>
+                                  <td>
+                                    <label
+                                      htmlFor={item.id}
+                                    >{`${item.itemName}`}</label>
+                                  </td>
                                   <td>
                                     <input
                                       type="checkbox"
@@ -260,6 +264,7 @@ const ListLayout = ({ items, localToken }) => {
                                         handleCheckboxChange(e, item)
                                       }
                                       name={item.id}
+                                      id={item.id}
                                       aria-label={item.itemName}
                                       disabled={isWithin24hours(
                                         item.purchasedDate,

--- a/src/components/ListLayout.jsx
+++ b/src/components/ListLayout.jsx
@@ -9,6 +9,7 @@ import { ONE_DAY_IN_MILLISECONDS, isWithin24hours } from '../utilities';
 import { itemStatusGroups } from '../configuration';
 import ListNameCopy from './ListNameCopy';
 import ExitList from './ExitList';
+import GradientFrame from './GradientFrame';
 
 const ListLayout = ({ items, localToken }) => {
   const [filter, setFilter] = useState('');
@@ -142,7 +143,7 @@ const ListLayout = ({ items, localToken }) => {
   return (
     <>
       <Toaster />
-      <div className="mx-auto w-5/6 md:w-1/2">
+      <div className="mx-auto w-5/6 md:w-4/5">
         {/* search and save features */}
         <div className="top-20 sticky flex flex-col md:flex-row justify-between py-2 px-12 bg-sky-100 rounded-3xl text-gray-600 focus-within:text-gray-400">
           <div className="flex flex-col">
@@ -216,16 +217,14 @@ const ListLayout = ({ items, localToken }) => {
               group.groupFilter(item),
             );
             return (
-              <section
-                key={idx}
-                className={`rounded-3xl p-2 md:p-12 ${group.colorClass} mt-6`}
-              >
+              <GradientFrame key={idx} colorClass={group.colorClass}>
                 <div className="flex flex-col md:flex-row justify-between border-b-2">
                   <h1 className="text-xl font-semibold text-blue-700">
                     {group.label}
                   </h1>
                   <p className="text-gray-500">{group.sublabel}</p>
                 </div>
+
                 {
                   //this only checks if the group has any items
                   itemsGrouped.length > 0 ? (
@@ -248,7 +247,7 @@ const ListLayout = ({ items, localToken }) => {
                             //the matching group items are mapped together in the section they belong
                             itemsGrouped.map((item, idx) => {
                               return (
-                                <tr className="h-8">
+                                <tr key={item.id} className="h-8">
                                   <td>{`${item.itemName}`}</td>
                                   <td>
                                     <input
@@ -292,7 +291,7 @@ const ListLayout = ({ items, localToken }) => {
                     </p>
                   )
                 }
-              </section>
+              </GradientFrame>
             );
           })
         }

--- a/src/components/ListLayout.jsx
+++ b/src/components/ListLayout.jsx
@@ -232,15 +232,17 @@ const ListLayout = ({ items, localToken }) => {
                       <summary className="text-gray-500">Toggle List</summary>
                       <table className="table-fixed text-center mx-auto">
                         <thead>
-                          <th className="p-4 text-gray-600 hidden md:table-cell">
-                            item name
-                          </th>
-                          <th className="p-4 text-gray-600 hidden md:table-cell">
-                            purchased
-                          </th>
-                          <th className="p-4 text-gray-600 hidden md:table-cell">
-                            delete
-                          </th>
+                          <tr>
+                            <th className="p-4 text-gray-600 hidden md:table-cell">
+                              item name
+                            </th>
+                            <th className="p-4 text-gray-600 hidden md:table-cell">
+                              purchased
+                            </th>
+                            <th className="p-4 text-gray-600 hidden md:table-cell">
+                              delete
+                            </th>
+                          </tr>
                         </thead>
                         <tbody>
                           {

--- a/src/components/ListView.jsx
+++ b/src/components/ListView.jsx
@@ -43,17 +43,19 @@ function ListView() {
       {!isDataLoading && (
         <div className="m-25">
           {items.length ? (
-            <ListLayout
-              items={items}
-              localToken={localToken}
-              loading={isDataLoading}
-            />
+            <>
+              <ListLayout
+                items={items}
+                localToken={localToken}
+                loading={isDataLoading}
+              />
+              <Navigation />
+            </>
           ) : (
             <Welcome />
           )}
         </div>
       )}
-      <Navigation />
     </>
   );
 }

--- a/src/components/Welcome.jsx
+++ b/src/components/Welcome.jsx
@@ -8,7 +8,7 @@ function Welcome() {
         Welcome!
       </h1>
 
-      <div className="rounded-xl w-1/2 mx-auto  mt-10 bg-gradient-to-r p-4 from-teal-500 via-teal-500 to-teal-500">
+      <div className="rounded-xl w-1/2 mx-auto  mt-10 bg-gradient-to-r p-4 from-teal-500 via-teal-600 to-teal-500">
         <div className="flex flex-col justify-between  py-20 bg-white text-white rounded-lg p-4">
           <div className="text-black mx-auto bg-white transform transition duration-500 hover:scale-110 hover:bg-amber-300 font-semibold py-2 px-4 border border-2 border-gradient-to-t from-amber-600 to-amber-600 via-amber-600 rounded shadow text-center md:w-1/4">
             <Link to="/addItemView">Start Your List</Link>

--- a/src/components/Welcome.jsx
+++ b/src/components/Welcome.jsx
@@ -8,7 +8,7 @@ function Welcome() {
         Welcome!
       </h1>
 
-      <div className="rounded-xl w-1/2 mx-auto  mt-10 bg-gradient-to-r p-4 from-teal-500 via-teal-600 to-teal-500">
+      <div className="rounded-xl w-3/4 md:w-1/2 mx-auto  mt-10 bg-gradient-to-r p-4 from-teal-500 via-teal-600 to-teal-500">
         <div className="flex flex-col justify-between  py-20 bg-white text-white rounded-lg p-4">
           <div className="text-black mx-auto bg-white transform transition duration-500 hover:scale-110 hover:bg-amber-300 font-semibold py-2 px-4 border border-2 border-gradient-to-t from-amber-600 to-amber-600 via-amber-600 rounded shadow text-center md:w-1/4">
             <Link to="/addItemView">Start Your List</Link>

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -25,7 +25,7 @@ export const itemStatusGroups = [
     groupFilter: (item) => {
       return item.previousEstimate < 7 && item.isActive === true;
     },
-    colorClass: 'bg-white border-8 border-teal-500',
+    colorClass: 'from-teal-500 via-teal-600 to-amber-300',
   },
   {
     label: 'Kind of soon',
@@ -37,7 +37,7 @@ export const itemStatusGroups = [
         item.isActive === true
       );
     },
-    colorClass: 'bg-white border-8 border-amber-300',
+    colorClass: 'from-amber-300 via-amber-400 to-rose-500',
   },
   {
     label: 'Not soon',
@@ -45,7 +45,7 @@ export const itemStatusGroups = [
     groupFilter: (item) => {
       return item.previousEstimate >= 30 && item.isActive === true;
     },
-    colorClass: 'bg-white border-8 border-rose-500',
+    colorClass: 'from-rose-500 via-rose-600 to-gray-500',
   },
   {
     label: 'Inactive',
@@ -53,6 +53,6 @@ export const itemStatusGroups = [
     groupFilter: (item) => {
       return item.isActive === false;
     },
-    colorClass: 'bg-white border-8 border-gray-500',
+    colorClass: 'from-gray-500 via-gray-600 to-gray-300',
   },
 ];

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -25,7 +25,7 @@ export const itemStatusGroups = [
     groupFilter: (item) => {
       return item.previousEstimate < 7 && item.isActive === true;
     },
-    colorClass: 'from-teal-500 via-teal-600 to-amber-300',
+    colorClass: 'from-teal-500 via-teal-600 to-teal-300',
   },
   {
     label: 'Kind of soon',
@@ -37,7 +37,7 @@ export const itemStatusGroups = [
         item.isActive === true
       );
     },
-    colorClass: 'from-amber-300 via-amber-400 to-rose-500',
+    colorClass: 'from-amber-500 via-amber-600 to-amber-300',
   },
   {
     label: 'Not soon',
@@ -45,7 +45,7 @@ export const itemStatusGroups = [
     groupFilter: (item) => {
       return item.previousEstimate >= 30 && item.isActive === true;
     },
-    colorClass: 'from-rose-500 via-rose-600 to-gray-500',
+    colorClass: 'from-rose-500 via-rose-600 to-rose-300',
   },
   {
     label: 'Inactive',

--- a/src/index.css
+++ b/src/index.css
@@ -1,7 +1,8 @@
 @import url('https://fonts.googleapis.com/css2?family=Exo:wght@200&family=Inconsolata:wght@500&family=Staatliches&display=swap&family=Karma:wght@500&display=swap');
 body {
   margin: 0;
-  background-color: #0369a1;
+  height: 100vh;
+  background: linear-gradient(90deg, #0369a1 0%, #14b8a6 100%);
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;


### PR DESCRIPTION
_For an example of how to fill this template out, [see this Pull Request](https://github.com/the-collab-lab/tcl-3-smart-shopping-list/pull/44)._ 

## Description
Added colorful gradient to each items container. Created Gradient Frame component to use for repeated styles.
Added keys to items and <tr> (table row) element - no more warning in the console.
Removed nav bar from Welcome page.


## Related Issue

<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->

## Acceptance Criteria

<!-- Include AC from the Github issue -->

## Type of Changes

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|   ✓ | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before
<img width="812" alt="beforeGradient" src="https://user-images.githubusercontent.com/83471057/156692839-0a99a5ed-3b75-414a-a27c-ade6bb9f38d6.png">

<img width="813" alt="errors" src="https://user-images.githubusercontent.com/83471057/156693053-b4094df9-be23-4140-bdc8-ed43b5fb3ac6.png">

### After
<img width="782" alt="gradient-borders-via" src="https://user-images.githubusercontent.com/83471057/156692536-b3a2257f-ee8e-41cd-a509-a572e30ae972.png">


## Testing Steps / QA Criteria

Pull down the branch, check that it is no more warning in the console. Enjoy  colorful frame around each container.

